### PR TITLE
[tzdata-timed] Fixed some unsupported zones JB#55243

### DIFF
--- a/data/MCC-unsupported-zones
+++ b/data/MCC-unsupported-zones
@@ -49,6 +49,11 @@ XK
 # remove MQ from the MCC list. GP and MQ both use ECT (UTC-04), so setting time 
 # based on GP should work when in MQ
 MQ
+# Update to the above ^: GP, MQ + a bunch of other islands are henceforth
+# lumped together as the French Antilles (BL). Great. Except they now share the
+# MCC 340 with French Guiana (GF) which uses (UTC-03). Not so great. Since GF
+# only has a fraction of the inhabitants of the islands, they're out of luck.
+^340.*GF
 
 # Operators providing service in the State of Palestine (PS) shares the
 # MCC with Israel 425 (IL). Remove PS, setting time based on MCC 425 will
@@ -66,3 +71,14 @@ MQ
 # unusable by timed. There's no easy mapping between the contry code 362 and
 # the locations formerly included in Netherlands Antilles.
 ^362.*AN
+
+# Cayman Islands (KY) (UTC-05) and Saint Lucia (SL) (UTC-04) both have MCC's
+# of 388. Since Saint Lucia has approximately twice the population of
+# Cayman Islands... I guess it sucks to be Cayman Islands.
+^338.*KY
+
+# Belgium shares 2 networks with Luxembourg 270 77 and 270 99, even though most
+# of Belgium uses MCC 206. (All of Luxembourg uses 270). Both are (UTC+01),
+# so not a major issue.
+^270.*77.*BE
+^270.*99.*BE

--- a/scripts/find_overlaps.sh
+++ b/scripts/find_overlaps.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Quick'n'dirty script to help identify pain points in the MCC file.
+# Use like this:
+# cat data/MCC | grep ^[0-9] | sort -k1 -k2 | ./find_overlaps.sh
+#
+# This will give you a list of things that you can then further investigate
+# (i.e. grep for and compare to the stuff already in MCC-unsupported-zones)
+
+old=""
+while read LINE ; do
+  new=`echo $LINE | cut -d ' ' -f1,2`
+  if [[ "$old" == "$new" ]] ; then
+    echo $LINE
+  fi
+  old=$new
+done < /dev/stdin


### PR DESCRIPTION
The previous update to newer Wikipedia data failed to take into account some of the changes needed for MCC-unsupported zones. This update fixes the issues and adds a simple script to help troubleshooting issues like these.