### PR TITLE
[tzdata-timed] Avoid pcre dependency. JB#63624

### DIFF
--- a/rpm/tzdata-timed.spec
+++ b/rpm/tzdata-timed.spec
@@ -4,7 +4,6 @@ Version:    2025b
 Release:    1
 License:    Public Domain
 BuildArch:  noarch
-BuildRequires: pcre
 URL:        https://github.com/sailfishos/tzdata-timed
 Source0:    %{name}-%{version}.tar.bz2
 Requires:   tzdata

--- a/scripts/zone-generate.sh
+++ b/scripts/zone-generate.sh
@@ -103,5 +103,5 @@ zones=$(
 
 ( cd $output && md5sum $zones ) > $md5sum
 $signature $output $zones > $signatures
-cat $input | pcregrep '^\s*Link\s+' > $links
+cat $input | grep -E '^\s*Link\s+' > $links
 

--- a/scripts/zone-list.sh
+++ b/scripts/zone-list.sh
@@ -61,7 +61,7 @@ for continent in $input ; do
   test -f $continent
 done
 
-cat $input | pcregrep -v '^\s*Link\s+' | tee $build_dir/aaaa | $zic_cmd -d $output 2> $build_dir/stderr -
+cat $input | grep -E -v '^\s*Link\s+' | tee $build_dir/aaaa | $zic_cmd -d $output 2> $build_dir/stderr -
 cat $build_dir/stderr | grep -v "time zone abbreviation differs from POSIX standard" >&2 || true
 
 {


### PR DESCRIPTION
Plain grep should be good enough for basic grepping.

Alternative to #8 by avoiding even the pcre2 dependency.